### PR TITLE
Change email body and alternative templates types

### DIFF
--- a/content/en/examples/bulk-mailer.md
+++ b/content/en/examples/bulk-mailer.md
@@ -92,11 +92,11 @@ func main() {
 		m.SetDate()
 		m.SetBulk()
 		m.Subject(fmt.Sprintf("%s, we have a great offer for you!", u.Firstname))
-		if err := m.SetBodyHTMLTemplate(htpl, u); err != nil {
-			log.Fatalf("failed to set HTML template as HTML body: %s", err)
+		if err := m.SetBodyTextTemplate(ttpl, u); err != nil {
+			log.Fatalf("failed to add text template to mail body: %s", err)
 		}
-		if err := m.AddAlternativeTextTemplate(ttpl, u); err != nil {
-			log.Fatalf("failed to set text template as alternative body: %s", err)
+		if err := m.AddAlternativeHTMLTemplate(htpl, u); err != nil {
+			log.Fatalf("failed to add HTML template to mail body: %s", err)
 		}
 
 		ms = append(ms, m)


### PR DESCRIPTION
Swapped the methods for setting the body and alternative body of the email. Since the RFC recommends putting the main content at last, this prioritizes the HTML content over the text body.

This PR is a short-term fix for: https://github.com/wneessen/go-mail/issues/251